### PR TITLE
remove erroneous `=` from `Persistent.mo`

### DIFF
--- a/src/Persistent.mo
+++ b/src/Persistent.mo
@@ -49,7 +49,7 @@ module {
     edges : Sequence.Sequence<EdgeInfo<I, E>>;
   };
 
-  public func empty<I, N, E>(_nodeId : NodeId<I>) : Graph<I, N, E> = {
+  public func empty<I, N, E>(_nodeId : NodeId<I>) : Graph<I, N, E> {
     {
       nodeId = _nodeId;
       nodes = Trie.empty();


### PR DESCRIPTION
hi there! came across syntax error when I was playing with `vessel`. 
fixes:

```
Stderr:
.vessel/graph/master/src/Persistent.mo:53.5-53.6: syntax error [M0001], unexpected token '{', expected one of token or <phrase> sequence:
  }
  seplist(<exp_field>,<semicolon>) }
```